### PR TITLE
Change string for ping sweep method

### DIFF
--- a/portscan.sh
+++ b/portscan.sh
@@ -264,7 +264,7 @@ if test $(which arping); then
 		printf "\n[-] ARP ping disabled as root may be required, [ -h | --help ] for more information"
 		SWEEP_METHOD="ICMP"
 	else
-		SWEEP_METHOD="ICMP + ARP"
+		SWEEP_METHOD="ICMP/ARP"
 	fi
 else
 	SWEEP_METHOD="ICMP"


### PR DESCRIPTION
Fix proposed for issue #11. 
Alternative approaches:
Leaving string for -r case as "ICMP + ARP" rather than "ICMP/ARP":
`printf "\n[+] Sweeping for live hosts (%s)\n" $SWEEP_METHOD` could be changed to
`printf "\n[+] Sweeping for live hosts (%s %s %s)\n" $SWEEP_METHOD`

or 
printf statements associated with each if/else block in that section

or 
change printf to echo